### PR TITLE
fix: module version constraint operator syntax

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -3,7 +3,7 @@
 
 plugin "aws" {
     enabled = true
-    version = "0.12.0"
+    version = "0.14.0"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ This Terraform module helps you create the base of your networking infrastructur
 
 ## Architecture
 
-<p align="center">
-  <img src="https://raw.githubusercontent.com/aws-ia/terraform-aws-network-hubandspoke/main/images/architecture_diagram.png" alt="Simple" width="100%">
-</p>
+![Architecture diagram](https://github.com/aws-ia/terraform-aws-network-hubandspoke/blob/346b078adc3fc6ace62de2ba216a9ef92666b71b/images/architecture_diagram.png)
 
 ## Usage
 
@@ -157,7 +155,7 @@ central_vpcs = {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_central_vpcs"></a> [central\_vpcs](#module\_central\_vpcs) | aws-ia/vpc/aws | == 1.4.0 |
+| <a name="module_central_vpcs"></a> [central\_vpcs](#module\_central\_vpcs) | aws-ia/vpc/aws | = 1.4.0 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ module "central_vpcs" {
   for_each = var.central_vpcs
 
   source  = "aws-ia/vpc/aws"
-  version = "== 1.4.0"
+  version = "= 1.4.0"
 
   name               = try(each.value.name, each.key)
   vpc_id             = try(each.value.vpc_id, null)


### PR DESCRIPTION
Terraform throws an error during module initialisation. 

```
Initializing modules...

╷
│ Error: Invalid version constraint
│ 
│ Module "central_vpcs" (declared at .terraform/modules/network-hubandspoke/main.tf line 20) has invalid
│ version constraint "== 1.4.0": Malformed constraint: == 1.4.0.
```