### PR TITLE
fix: inspection was renamed to endpoints in code

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ central_vpcs = {
                 netmask = 24
                 nat_gateway_configuration = "all_azs"
             }
-            inspection = { netmask = 24 }
+            endpoints = { netmask = 24 }
             transit_gateway = { netmask = 28 }
         }
     }
@@ -101,7 +101,7 @@ central_vpcs = {
         az_count = 2
 
         subnets = {
-            inspection = { netmask = 24 }
+            endpoints = { netmask = 24 }
             transit_gateway = { netmask = 28 }
         }
     }
@@ -133,7 +133,7 @@ central_vpcs = {
         }
 
         subnets = {
-            inspection = { netmask = 24 }
+            endpoints = { netmask = 24 }
             transit_gateway = { netmask = 28 }
         }
     }


### PR DESCRIPTION
Hello!

While setting up the inspection VPC from the example in the README i figured out that inspection was renamed to endpoints. This PR updates the documentation.