### PR TITLE
fix: Use prefix in tgw-rtb when using PREFIX in network_definition.type

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ central_vpcs = {
                 netmask = 24
                 nat_gateway_configuration = "all_azs"
             }
-            inspection = { netmask = 24 }
+            endpoints = { netmask = 24 }
             transit_gateway = { netmask = 28 }
         }
     }
@@ -101,7 +101,7 @@ central_vpcs = {
         az_count = 2
 
         subnets = {
-            inspection = { netmask = 24 }
+            endpoints = { netmask = 24 }
             transit_gateway = { netmask = 28 }
         }
     }
@@ -133,7 +133,7 @@ central_vpcs = {
         }
 
         subnets = {
-            inspection = { netmask = 24 }
+            endpoints = { netmask = 24 }
             transit_gateway = { netmask = 28 }
         }
     }

--- a/main.tf
+++ b/main.tf
@@ -174,7 +174,7 @@ resource "aws_ec2_transit_gateway_route" "ingress_to_inspection_network_route" {
 }
 
 resource "aws_ec2_transit_gateway_prefix_list_reference" "ingress_to_inspection_network_prefix_list" {
-  count = local.ingress_to_inspection_network && !local.network_pl ? 1 : 0
+  count = local.ingress_to_inspection_network && local.network_pl ? 1 : 0
 
   prefix_list_id                 = var.network_definition.value
   transit_gateway_attachment_id  = module.central_vpcs["inspection"].transit_gateway_attachment_id


### PR DESCRIPTION
When using a prefix list like this:

```
module "hub-and-spoke" {
  source  = "aws-ia/network-hubandspoke/aws"
  version = "1.0.1"

  ......

  network_definition = {
    type  = "PREFIX_LIST"
    value = aws_ec2_managed_prefix_list.network_prefix_list.id
  }

  .......
```

The PREFIX list should be attached to the ingress route table to route traffic to the inspection VPC. However [both conditions](https://github.com/aws-ia/terraform-aws-network-hubandspoke/blob/85866cbe32735dbeb3ab76299d5bfcaad8e5810e/main.tf#L166-L182) are the same, so it will not use the [code](https://github.com/aws-ia/terraform-aws-network-hubandspoke/blob/85866cbe32735dbeb3ab76299d5bfcaad8e5810e/main.tf#L176-L182) to actually attach the prefix to the tgw-rtb.