### PR TITLE
fix: route from inspection to ingress (so spoke VPC can talk back with Load Balancers)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -145,6 +145,16 @@ resource "aws_ec2_transit_gateway_route" "inspection_to_egress_default_route" {
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.tgw_route_table["inspection"].id
 }
 
+# Static Route from Inspection VPC to Ingress VPC if:
+# 1/ Both Inspection VPC and Ingress VPC are created, and the traffic inspection is "all" or "north-south".  
+resource "aws_ec2_transit_gateway_route" "inspection_to_ingress_network_route" {
+  count = local.ingress_to_inspection_network && local.network_pl ? 1 : 0
+
+  destination_cidr_block         = module.central_vpcs["ingress"].vpc_attributes.cidr_block
+  transit_gateway_attachment_id  = module.central_vpcs["ingress"].transit_gateway_attachment_id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.tgw_route_table["inspection"].id
+}
+
 # Static Route (Network's CIDR) from Egress VPC to Inspection VPC if:
 # 1/ Both Inspection VPC and Egress VPC are created, and the traffic inspection is "all" or "north-south".
 resource "aws_ec2_transit_gateway_route" "egress_to_inspection_network_route" {


### PR DESCRIPTION
Hello! I deployed a setup with ingress/egress and an inspection VPC with the config below:

```
module "hub-and-spoke" {
  source  = "aws-ia/network-hubandspoke/aws"
  version = "1.0.1"

  identifier         = "development"
  transit_gateway_id = aws_ec2_transit_gateway.tgw.id

  network_definition = {
    type  = "PREFIX_LIST"
    value = aws_ec2_managed_prefix_list.network_prefix_list.id
  }

  spoke_vpcs = {
      application-x = {
          dev = {
              vpc_id = "vpc-123456"
              transit_gateway_attachment_id = "tgw-attach-123456"
          }
      }
  }

  central_vpcs = {
    egress = {
      name       = "egress-vpc"
      cidr_block = "10.0.1.0/24"
      az_count   = 3

      subnets = {
        public          = { netmask = 26 }
        transit_gateway = { netmask = 28 }
      }
    }

    ingress = {
      name       = "ingress-vpc"
      cidr_block = "10.0.0.0/24"
      az_count   = 3

      subnets = {
        public          = { netmask = 26 }
        transit_gateway = { netmask = 28 }
      }
    }

    inspection = {
        name = "inspection-vpc"
        cidr_block = "10.0.2.0/24"
        az_count = 3
        inspection_flow = "all"

        aws_network_firewall = {
            name = "firewall-dev"
            policy_arn = aws_networkfirewall_firewall_policy.test.arn
        }

        subnets = {
            endpoints       = { netmask = 26 }
            transit_gateway = { netmask = 28 }
        }
    }
  }
}
```

I found out when placing an EC2 machine or Load Balancer on the Ingress VPC the traffic never comes back when sending some data to a spoke VPC. I found out this is caused by the inspection VPC not having a route back to the Ingress VPC. This PR will add a route from inspection to ingress when using above setup. Or maybe I'm missing a setting somewhere that should enable this?