### PR TITLE
replace count with for_each in resources based on spoke_vpcs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -99,18 +99,18 @@ resource "aws_ec2_transit_gateway_route_table" "spokes_tgw_rt" {
 
 # Spoke VPC TGW association
 resource "aws_ec2_transit_gateway_route_table_association" "spokes_tgw_rt_association" {
-  count = local.number_vpcs
+  for_each = var.spoke_vpcs.vpc_information
 
-  transit_gateway_attachment_id  = local.vpc_information[count.index].transit_gateway_attachment_id
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.spokes_tgw_rt[try(local.vpc_information[count.index].routing_domain, "spokes")].id
+  transit_gateway_attachment_id  = each.value.transit_gateway_attachment_id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.spokes_tgw_rt[try(each.value.routing_domain, "spokes")].id
 }
 
 # Spoke VPC TGW propagation
 resource "aws_ec2_transit_gateway_route_table_propagation" "spokes_to_spokes_propagation" {
-  count = local.spoke_to_spoke_propagation ? local.number_vpcs : 0
+  for_each = local.spoke_to_spoke_propagation ? var.spoke_vpcs.vpc_information : {}
 
-  transit_gateway_attachment_id  = local.vpc_information[count.index].transit_gateway_attachment_id
-  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.spokes_tgw_rt[try(local.vpc_information[count.index].routing_domain, "spokes")].id
+  transit_gateway_attachment_id  = each.value.transit_gateway_attachment_id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.spokes_tgw_rt[try(each.value.routing_domain, "spokes")].id
 }
 
 # ---------------------- TRANSIT GATEWAY STATIC ROUTES ----------------------
@@ -241,12 +241,9 @@ resource "aws_ec2_transit_gateway_route_table_propagation" "ingress_to_inspectio
 
 # Spoke VPCs propagation to the Inspection RT - anytime this VPC is created
 resource "aws_ec2_transit_gateway_route_table_propagation" "spokes_to_inspection_propagation" {
-  count = (
-    local.spoke_to_inspection_propagation &&
-    try(local.associate_and_propagate_to_tgw["inspection"], true)
-  ) ? local.number_vpcs : 0
+  for_each = try(local.associate_and_propagate_to_tgw["inspection"], true) ? var.spoke_vpcs.vpc_information : {}
 
-  transit_gateway_attachment_id  = local.vpc_information[count.index].transit_gateway_attachment_id
+  transit_gateway_attachment_id  = each.value.transit_gateway_attachment_id
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.tgw_route_table["inspection"].id
 }
 


### PR DESCRIPTION
The problem with using count is that when you add or remove VPCs from the spoke_vpcs map, the count index will change. I would often have all the resources connected to my spoke_vpcs being destroyed and re-created. This was causing issues where connecitivity between VPC's was being temporarily lost during the apply phase.

This issue fixes #31. 

This change is not really backwards compatible. If you do nothing when you upgrade, than on the next apply you will have a small outage (same as when adding a new VPC). But it will only happen the one time and you can add and remove VPC's without outages. 

If you don't want the outage you can import and then state rm all of the effected resources. It would look something like this:

```
tofu state rm 'module.network_us_west.module.hub.aws_ec2_transit_gateway_route_table_propagation.spokes_to_inspection_propagation[0]'
tofu state rm 'module.network_us_west.module.hub.aws_ec2_transit_gateway_route_table_propagation.spokes_to_inspection_propagation[1]'
tofu state rm 'module.network_us_west.module.hub.aws_ec2_transit_gateway_route_table_propagation.spokes_to_inspection_propagation[2]'
tofu state rm 'module.network_us_west.module.hub.aws_ec2_transit_gateway_route_table_propagation.spokes_to_inspection_propagation[3]'
tofu state rm 'module.network_us_west.module.hub.aws_ec2_transit_gateway_route_table_propagation.spokes_to_inspection_propagation[4]'
tofu state rm 'module.network_us_west.module.hub.aws_ec2_transit_gateway_route_table_propagation.spokes_to_inspection_propagation[5]'
tofu state rm 'module.network_us_west.module.hub.aws_ec2_transit_gateway_route_table_propagation.spokes_to_inspection_propagation[6]'
```

```
tofu import 'module.network_us_west.module.hub.aws_ec2_transit_gateway_route_table_propagation.spokes_to_inspection_propagation["dev"]' 'tgw-rtb-XXX_tgw-attach-XXX'
....
```
